### PR TITLE
Check for project dir in verify function

### DIFF
--- a/flycheck-gradle.el
+++ b/flycheck-gradle.el
@@ -116,16 +116,21 @@ This needs to be set before `flycheck-gradle-setup' is called."
   "Return list of `flycheck-verification-result' for CHECKER using TARGETS."
   (let ((gradle (flycheck-checker-executable checker))
 	(default-directory (flycheck-gradle--find-gradle-project-directory checker)))
-    (mapcar  (lambda (target)
-	       (let ((success (eq 0 (call-process gradle nil nil nil
-						  "-quiet"
-						  "--console"
-						  "plain" "--dry-run" target))))
-		 (flycheck-verification-result-new
-		  :label target
-		  :message (if success "present" "missing")
-		  :face (if success 'success '(bold error)))))
-	     targets)))
+    (cons (flycheck-verification-result-new
+	   :label "project dir"
+	   :message (or default-directory "not found")
+	   :face (if default-directory 'success '(bold error)))
+	  (when default-directory
+	    (mapcar (lambda (target)
+		      (let ((success (eq 0 (call-process gradle nil nil nil
+							 "-quiet"
+							 "--console"
+							 "plain" "--dry-run" target))))
+			(flycheck-verification-result-new
+			 :label target
+			 :message (if success "present" "missing")
+			 :face (if success 'success '(bold error)))))
+		    targets)))))
 
 (flycheck-define-checker gradle-kotlin
   "Flycheck plugin for for Gradle."


### PR DESCRIPTION
Prevents error when `flycheck-gradle--find-gradle-project-directory'
returns nil:

```
Debugger entered--Lisp error: (wrong-type-argument stringp nil)
  call-process("gradle" nil nil nil "-quiet" "--console" "plain" "--dry-run" "build")
  (eq 0 (call-process gradle nil nil nil "-quiet" "--console" "plain" "--dry-run" target))
  (let ((success (eq 0 (call-process gradle nil nil nil "-quiet" "--console" "plain" "--dry-run" target)))) (progn "Constructor for objects of type `flycheck-verification-result'." nil (vector (quote cl-struct-flycheck-verification-result) target (if success "present" "missing") (if success (quote success) (quote (bold error))))))
  (closure ((gradle . "gradle") (targets "build") (checker . gradle-java) t) (target) (let ((success (eq 0 (call-process gradle nil nil nil "-quiet" "--console" "plain" "--dry-run" target)))) (progn "Constructor for objects of type `flycheck-verification-result'." nil (vector (quote cl-struct-flycheck-verification-result) target (if success "present" "missing") (if success (quote success) (quote (bold error)))))))("build")
  mapcar((closure ((gradle . "gradle") (targets "build") (checker . gradle-java) t) (target) (let ((success (eq 0 (call-process gradle nil nil nil "-quiet" "--console" "plain" "--dry-run" target)))) (progn "Constructor for objects of type `flycheck-verification-result'." nil (vector (quote cl-struct-flycheck-verification-result) target (if success "present" "missing") (if success (quote success) (quote (bold error))))))) ("build"))
  (let ((gradle (flycheck-checker-executable checker)) (default-directory (flycheck-gradle--find-gradle-project-directory checker))) (mapcar (function (lambda (target) (let ((success (eq 0 ...))) (progn "Constructor for objects of type `flycheck-verification-result'." nil (vector (quote cl-struct-flycheck-verification-result) target (if success "present" "missing") (if success ... ...)))))) targets))
  flycheck-gradle--verify(gradle-java ("build"))

```