### PR TITLE
Add minimal Java compile target function

### DIFF
--- a/flycheck-gradle.el
+++ b/flycheck-gradle.el
@@ -303,6 +303,17 @@ output as a string."
         `(,cmd)
       `("clean" ,cmd))))
 
+(defun flycheck-gradle-java-compile->compile ()
+  "Target gradle compile for java."
+  (let ((cmd (if (and
+                  buffer-file-name
+                  (string-match-p "test" buffer-file-name))
+                 "compileTestJava"
+               "compileJava")))
+    (if (flycheck-has-current-errors-p 'error)
+        `(,cmd)
+      `("clean" ,cmd))))
+
 (defun flycheck-gradle-java-compile->android ()
   "Target gradle compile for android java."
   (let ((cmd


### PR DESCRIPTION
Thanks very much for your changes relating to #1. I've had success with this target-generating function for Java.