### PR TITLE
Update Kotlin compile commands

### DIFF
--- a/flycheck-gradle.el
+++ b/flycheck-gradle.el
@@ -302,8 +302,8 @@ output as a string."
   (let ((cmd (if (and
                   buffer-file-name
                   (string-match-p "test" buffer-file-name))
-                 "compileDebugUnitTestKotlin"
-               "compileReleaseKotlin")))
+                 "compileTestKotlin"
+               "compileKotlin")))
     (if (flycheck-has-current-errors-p 'error)
         `(,cmd)
       `("clean" ,cmd))))


### PR DESCRIPTION
Current compile commands don't work for me. These updated ones do.

```
$ gradle -version

------------------------------------------------------------
Gradle 4.10.1
------------------------------------------------------------

Build time:   2018-09-12 11:33:27 UTC
Revision:     76c9179ea9bddc32810f9125ad97c3315c544919

Kotlin DSL:   1.0-rc-6
Kotlin:       1.2.61
Groovy:       2.4.15
Ant:          Apache Ant(TM) version 1.9.11 compiled on March 23 2018
JVM:          10.0.2 (Oracle Corporation 10.0.2+13)
OS:           Linux 4.18.9-arch1-1-ARCH amd64
```